### PR TITLE
chore(deploy): set up GitHub Pages workflow and landing page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Paste link. Agent sets skills.
 - `contracts/` : 에이전트 지침 계약 문서
 - `packs/` : 스킬 팩 데이터
 - `examples/` : 사용자 플로우 예시
+- `site/` : GitHub Pages 정적 사이트
+
+## GitHub Pages
+- 배포 방식: GitHub Actions (`.github/workflows/pages.yml`)
+- 기본 URL: `https://qpwoei0123.github.io/JustPaste/`

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JustPaste</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 760px; margin: 48px auto; padding: 0 16px; line-height: 1.6; }
+      h1 { margin-bottom: 8px; }
+      .muted { color: #666; }
+      code { background: #f3f3f3; padding: 2px 6px; border-radius: 6px; }
+      ul { padding-left: 20px; }
+    </style>
+  </head>
+  <body>
+    <h1>JustPaste</h1>
+    <p class="muted">Paste link. Agent sets skills.</p>
+
+    <h2>What is this?</h2>
+    <p>
+      JustPaste는 링크 하나를 에이전트에 붙여넣으면, 에이전트가 지침을 읽고
+      스킬 선택/적용을 안내하는 AI-우선 스킬 세팅 허브입니다.
+    </p>
+
+    <h2>Demo packs</h2>
+    <ul>
+      <li><code>commit-convention</code></li>
+      <li><code>pr-clarity-template</code></li>
+    </ul>
+
+    <h2>Repository</h2>
+    <p><a href="https://github.com/qpwoei0123/JustPaste">github.com/qpwoei0123/JustPaste</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## 요약
- GitHub Pages 배포 파이프라인과 기본 랜딩 페이지를 추가했습니다.

## 변경 내용
-  추가 (Actions 기반 배포)
-  추가 (기본 소개 페이지)
- README에 Pages URL/설명 추가

## 범위
- 포함: Pages 배포 기본 세팅
- 제외: 동적 기능/API 연동

## 관련 이슈
Closes #20