### PR TITLE
feat(api): add static pack instruction endpoint for mvp

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ Paste link. Agent sets skills.
 ## GitHub Pages
 - 배포 방식: GitHub Actions (`.github/workflows/pages.yml`)
 - 기본 URL: `https://qpwoei0123.github.io/JustPaste/`
+
+## API (MVP, static)
+- Pack instruction endpoint (example):
+  - `/api/v1/packs/commit-convention/instruction.json`
+  - `/api/v1/packs/pr-clarity-template/instruction.json`

--- a/docs/api-pack-instruction-endpoint.md
+++ b/docs/api-pack-instruction-endpoint.md
@@ -1,0 +1,35 @@
+# Pack Instruction Endpoint (v1)
+
+## Endpoint
+- `GET /api/v1/packs/{packId}/instruction.json`
+
+## Success Response (200)
+```json
+{
+  "packId": "commit-convention",
+  "revision": 1,
+  "contractVersion": "instruction.v0",
+  "steps": [
+    "Read pack metadata",
+    "Show selectable options to user",
+    "Confirm scope before apply"
+  ],
+  "source": {
+    "instructionPath": "packs/commit-convention/instruction.md"
+  }
+}
+```
+
+## Error Response (404)
+```json
+{
+  "error": {
+    "code": "PACK_NOT_FOUND",
+    "message": "No pack found for given packId"
+  }
+}
+```
+
+## Notes
+- For MVP on GitHub Pages, endpoints are served as static JSON files.
+- Dynamic routing/validation will be added in API implementation phase.

--- a/site/api/v1/errors/pack-not-found.json
+++ b/site/api/v1/errors/pack-not-found.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "PACK_NOT_FOUND",
+    "message": "No pack found for given packId"
+  }
+}

--- a/site/api/v1/packs/commit-convention/instruction.json
+++ b/site/api/v1/packs/commit-convention/instruction.json
@@ -1,0 +1,15 @@
+{
+  "packId": "commit-convention",
+  "revision": 1,
+  "contractVersion": "instruction.v0",
+  "steps": [
+    "Read pack metadata and instruction",
+    "Show skill summary and cautions",
+    "Ask user to choose apply scope (project/global)",
+    "Ask overwrite confirmation when needed",
+    "Apply and report result"
+  ],
+  "source": {
+    "instructionPath": "packs/commit-convention/instruction.md"
+  }
+}

--- a/site/api/v1/packs/pr-clarity-template/instruction.json
+++ b/site/api/v1/packs/pr-clarity-template/instruction.json
@@ -1,0 +1,15 @@
+{
+  "packId": "pr-clarity-template",
+  "revision": 1,
+  "contractVersion": "instruction.v0",
+  "steps": [
+    "Read pack metadata and instruction",
+    "Show template sections to user",
+    "Ask user to choose apply scope (project/global)",
+    "Ask overwrite confirmation when needed",
+    "Apply and report result"
+  ],
+  "source": {
+    "instructionPath": "packs/pr-clarity-template/instruction.md"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a machine-readable pack instruction endpoint for MVP using static JSON on GitHub Pages.

## Changes
- Add endpoint spec doc: 
- Add static instruction endpoints:
  - 
  - 
- Add static 404 error shape example:
  - 
- Update README with API paths

## Scope
- In scope: endpoint shape + static JSON delivery for MVP
- Out of scope: dynamic routing/server-side validation

## Related issue
Closes #5