### PR TITLE
feat(api): add static skill list endpoint for mvp

### DIFF
--- a/docs/api-skill-list-endpoint.md
+++ b/docs/api-skill-list-endpoint.md
@@ -1,0 +1,6 @@
+# Skill List Endpoint (v1)
+
+## Endpoint
+- `GET /api/v1/packs/index.json`
+
+Returns all selectable packs for MVP.

--- a/site/api/v1/packs/index.json
+++ b/site/api/v1/packs/index.json
@@ -1,0 +1,20 @@
+{
+  "packs": [
+    {
+      "id": "commit-convention",
+      "name": "Commit Convention",
+      "summary": "컨벤셔널 커밋 규칙으로 메시지 일관성을 맞춥니다.",
+      "revision": 1,
+      "risk": "low",
+      "tags": ["git", "commit", "convention"]
+    },
+    {
+      "id": "pr-clarity-template",
+      "name": "PR Clarity Template",
+      "summary": "PR 설명을 요약/범위/검증 중심으로 통일합니다.",
+      "revision": 1,
+      "risk": "low",
+      "tags": ["github", "pull-request", "template"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a static skill list endpoint for MVP.

## Changes
- Add `site/api/v1/packs/index.json`
- Add `docs/api-skill-list-endpoint.md`

## Scope
- In scope: static list response for GitHub Pages
- Out of scope: server-side filtering/pagination

## Related issue
Closes #6
