### PR TITLE
docs(flow): add Claude Code setup instruction example

### DIFF
--- a/examples/claude-code-flow.md
+++ b/examples/claude-code-flow.md
@@ -1,0 +1,8 @@
+# Claude Code Setup Flow Example
+
+- Read JustPaste link and instruction.
+- Show selectable packs with summary.
+- Ask selection and confirm chosen IDs.
+- Ask apply scope (project/global).
+- Ask overwrite confirmation when needed.
+- Apply and report changed files.


### PR DESCRIPTION
## Summary
- Add Claude Code setup flow example documentation.

## Changes
- Add `examples/claude-code-flow.md`

## Scope
- In scope: conversational/apply flow example
- Out of scope: adapter implementation

## Related issue
Closes #9
