### PR TITLE
docs(flow): add Codex setup instruction example

### DIFF
--- a/examples/codex-flow.md
+++ b/examples/codex-flow.md
@@ -1,0 +1,8 @@
+# Codex Setup Flow Example
+
+- Read JustPaste link and instruction.
+- Show selectable packs with summary.
+- Ask selection and confirm chosen IDs.
+- Ask apply scope (project/global).
+- Ask overwrite confirmation when needed.
+- Apply and report changed files.


### PR DESCRIPTION
## Summary
- Add Codex setup flow example documentation.

## Changes
- Add `examples/codex-flow.md`

## Scope
- In scope: conversational/apply flow example
- Out of scope: adapter implementation

## Related issue
Closes #10
