### PR TITLE
docs(security): add trust model and risk notes

### DIFF
--- a/docs/TRUST_MODEL.md
+++ b/docs/TRUST_MODEL.md
@@ -1,0 +1,15 @@
+# Trust Model and Risk Notes
+
+## Boundaries
+- User-provided links are untrusted input.
+- Repository pack content is trusted source.
+
+## Safeguards
+- Confirm scope (project/global) before apply.
+- Confirm overwrite before write.
+- Prefer dry-run before real apply.
+
+## Main risks
+- Malicious links
+- Unintended global writes
+- Silent overwrite


### PR DESCRIPTION
## Summary
- Add trust model and risk notes.

## Changes
- Add `docs/TRUST_MODEL.md`

## Scope
- In scope: trust boundaries, risks, safeguards
- Out of scope: policy engine implementation

## Related issue
Closes #12
