### PR TITLE
docs: #60 pack id naming convention

### DIFF
--- a/docs/pack-id-naming-convention.md
+++ b/docs/pack-id-naming-convention.md
@@ -1,0 +1,4 @@
+# Pack ID Naming Convention
+- 소문자 kebab-case만 허용: `^[a-z][a-z0-9-]*$`
+- 길이 3~40자
+- 예약어: `api`, `admin`, `system`, `internal`, `null`, `default`


### PR DESCRIPTION
Closes #60